### PR TITLE
Unlock response length, language, and auto-scroll for all users

### DIFF
--- a/freely/src/pages/responses/components/AutoScrollToggle.tsx
+++ b/freely/src/pages/responses/components/AutoScrollToggle.tsx
@@ -1,10 +1,8 @@
 import { Switch, Label, Header } from "@/components";
-import { useApp } from "@/contexts";
 import { useState, useEffect } from "react";
 import { getResponseSettings, updateAutoScroll } from "@/lib";
 
 export const AutoScrollToggle = () => {
-  const { hasActiveLicense } = useApp();
   const [autoScroll, setAutoScroll] = useState<boolean>(true);
 
   useEffect(() => {
@@ -13,9 +11,6 @@ export const AutoScrollToggle = () => {
   }, []);
 
   const handleSwitchChange = (checked: boolean) => {
-    if (!hasActiveLicense) {
-      return;
-    }
     setAutoScroll(checked);
     updateAutoScroll(checked);
   };
@@ -44,7 +39,6 @@ export const AutoScrollToggle = () => {
         <Switch
           checked={autoScroll}
           onCheckedChange={handleSwitchChange}
-          disabled={!hasActiveLicense}
           title={`Toggle to ${!autoScroll ? "enable" : "disable"} auto-scroll`}
           aria-label={`Toggle to ${
             autoScroll ? "disable" : "enable"

--- a/freely/src/pages/responses/components/LanguageSelector.tsx
+++ b/freely/src/pages/responses/components/LanguageSelector.tsx
@@ -1,12 +1,10 @@
 import { Header, Selection } from "@/components";
 import { LANGUAGES } from "@/lib";
-import { useApp } from "@/contexts";
 import { updateLanguage } from "@/lib/storage/response-settings.storage";
 import { useState, useEffect, useMemo } from "react";
 import { getResponseSettings } from "@/lib";
 
 export const LanguageSelector = () => {
-  const { hasActiveLicense } = useApp();
   const [selectedLanguage, setSelectedLanguage] = useState<string>("english");
 
   useEffect(() => {
@@ -15,9 +13,6 @@ export const LanguageSelector = () => {
   }, []);
 
   const handleLanguageChange = (languageId: string) => {
-    if (!hasActiveLicense) {
-      return;
-    }
     setSelectedLanguage(languageId);
     updateLanguage(languageId);
   };
@@ -43,7 +38,6 @@ export const LanguageSelector = () => {
           onChange={handleLanguageChange}
           options={languageOptions}
           placeholder="Select a language"
-          disabled={!hasActiveLicense}
         />
       </div>
     </div>

--- a/freely/src/pages/responses/components/ResponseLength.tsx
+++ b/freely/src/pages/responses/components/ResponseLength.tsx
@@ -1,13 +1,11 @@
 import { Card, Header } from "@/components";
 import { RESPONSE_LENGTHS } from "@/lib";
-import { useApp } from "@/contexts";
 import { updateResponseLength } from "@/lib/storage/response-settings.storage";
 import { useState, useEffect } from "react";
 import { getResponseSettings } from "@/lib";
 import { CheckCircle2 } from "lucide-react";
 
 export const ResponseLength = () => {
-  const { hasActiveLicense } = useApp();
   const [selectedLength, setSelectedLength] = useState<string>("auto");
 
   useEffect(() => {
@@ -16,9 +14,6 @@ export const ResponseLength = () => {
   }, []);
 
   const handleLengthChange = (lengthId: string) => {
-    if (!hasActiveLicense) {
-      return;
-    }
     setSelectedLength(lengthId);
     updateResponseLength(lengthId);
   };
@@ -39,7 +34,7 @@ export const ResponseLength = () => {
               selectedLength === length.id
                 ? "border-primary"
                 : "border-border hover:border-primary/50"
-            } ${!hasActiveLicense ? "opacity-50 cursor-not-allowed" : ""}`}
+            }`}
             onClick={() => handleLengthChange(length.id)}
           >
             <div className="space-y-1">

--- a/freely/src/pages/responses/index.tsx
+++ b/freely/src/pages/responses/index.tsx
@@ -4,29 +4,13 @@ import {
   AutoScrollToggle,
 } from "./components";
 import { PageLayout } from "@/layouts";
-import { useApp } from "@/contexts";
 
 const Responses = () => {
-  const { hasActiveLicense } = useApp();
-
   return (
     <PageLayout
       title="Response Settings"
       description="Customize how AI generates and displays responses"
     >
-      {!hasActiveLicense && (
-        <div className="p-4 bg-primary/10 border border-primary/20 rounded-lg">
-          <p className="text-[10px] lg:text-sm text-foreground font-medium mb-2">
-            🔒 Premium Features
-          </p>
-          <p className="text-[10px] lg:text-sm text-muted-foreground">
-            Response customization features (Response Length, Language
-            Selection, and Auto-Scroll Control) require an active license to
-            use.
-          </p>
-        </div>
-      )}
-
       {/* Response Length */}
       <ResponseLength />
 


### PR DESCRIPTION
## Summary
- Response length (Short/Medium/Long/Auto) no longer gated
- Language selection no longer gated
- Auto-scroll toggle no longer gated
- Warning banner removed from responses page
- Closes #22, Closes #23, Closes #24

## Test plan
- [ ] TypeScript compiles without errors
- [ ] Response length cards are clickable
- [ ] Language dropdown works
- [ ] Auto-scroll toggle works