### PR TITLE
Unlock drag/resize and window move shortcuts for all users

### DIFF
--- a/freely/src-tauri/src/lib.rs
+++ b/freely/src-tauri/src/lib.rs
@@ -46,7 +46,6 @@ pub fn run() {
             is_hidden: Mutex::new(false),
         })
         .manage(shortcuts::RegisteredShortcuts::default())
-        .manage(shortcuts::LicenseState::default())
         .manage(shortcuts::MoveWindowState::default())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -86,7 +85,6 @@ pub fn run() {
             shortcuts::get_registered_shortcuts,
             shortcuts::update_shortcuts,
             shortcuts::validate_shortcut_key,
-            shortcuts::set_license_status,
             shortcuts::set_app_icon_visibility,
             shortcuts::set_always_on_top,
             shortcuts::exit_app,

--- a/freely/src-tauri/src/shortcuts.rs
+++ b/freely/src-tauri/src/shortcuts.rs
@@ -30,28 +30,6 @@ impl Default for RegisteredShortcuts {
     }
 }
 
-pub struct LicenseState {
-    has_active_license: AtomicBool,
-}
-
-impl Default for LicenseState {
-    fn default() -> Self {
-        LicenseState {
-            has_active_license: AtomicBool::new(true),
-        }
-    }
-}
-
-impl LicenseState {
-    pub fn is_active(&self) -> bool {
-        self.has_active_license.load(Ordering::Relaxed)
-    }
-
-    pub fn set_active(&self, active: bool) {
-        self.has_active_license.store(active, Ordering::Relaxed);
-    }
-}
-
 pub(crate) type MoveWindowTask = Arc<AtomicBool>;
 
 pub(crate) struct MoveWindowState {
@@ -477,20 +455,6 @@ pub fn validate_shortcut_key(key: String) -> Result<bool, String> {
             Ok(false)
         }
     }
-}
-
-#[tauri::command]
-pub fn set_license_status<R: Runtime>(app: AppHandle<R>, has_license: bool) -> Result<(), String> {
-    {
-        let state = app.state::<LicenseState>();
-        state.set_active(has_license);
-    }
-
-    if !has_license {
-        stop_all_move_windows(&app);
-    }
-
-    Ok(())
 }
 
 /// Tauri command to set app icon visibility in dock/taskbar

--- a/freely/src/contexts/app.context.tsx
+++ b/freely/src/contexts/app.context.tsx
@@ -154,16 +154,16 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   };
 
   useEffect(() => {
-    const syncLicenseState = async () => {
+    const syncShortcuts = async () => {
       try {
         const config = getShortcutsConfig();
         await invoke("update_shortcuts", { config });
       } catch (error) {
-        console.error("Failed to synchronize shortcut state:", error);
+        console.error("Failed to synchronize shortcuts:", error);
       }
     };
 
-    syncLicenseState();
+    syncShortcuts();
   }, [hasActiveLicense]);
 
   // Function to load AI, STT, system prompt and screenshot config data from storage


### PR DESCRIPTION
## Summary
- DragButton always enables drag region (removes license gate)
- Window move shortcuts always registered (removes license check in Rust)
- Closes #20, Closes #21

## Test plan
- [ ] TypeScript compiles without errors
- [ ] Rust compiles without errors
- [ ] Window can be dragged without license
- [ ] Move shortcuts work without license