### PR TITLE
Rename pluelyApiEnabled → freelyApiEnabled internal identifiers (#9)

### DIFF
--- a/freely/src/contexts/app.context.tsx
+++ b/freely/src/contexts/app.context.tsx
@@ -145,8 +145,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     safeLocalStorage.setItem(STORAGE_KEYS.SUPPORTS_IMAGES, String(value));
   };
 
-  // Pluely API State - always disabled (Freely API removed)
-  const [pluelyApiEnabled, setPluelyApiEnabledState] = useState<boolean>(false);
+  // Freely API State - always disabled (API removed)
+  const [freelyApiEnabled, setFreelyApiEnabledState] = useState<boolean>(false);
 
   const getActiveLicenseStatus = async () => {
     // License validation removed - always treated as active
@@ -649,9 +649,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     loadData();
   };
 
-  const setPluelyApiEnabled = async (_enabled: boolean) => {
+  const setFreelyApiEnabled = async (_enabled: boolean) => {
     // Freely API removed - always disabled
-    setPluelyApiEnabledState(false);
+    setFreelyApiEnabledState(false);
   };
 
   // Create the context value (extend IContextType accordingly)
@@ -674,8 +674,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     toggleAlwaysOnTop,
     toggleAutostart,
     loadData,
-    pluelyApiEnabled,
-    setPluelyApiEnabled,
+    freelyApiEnabled,
+    setFreelyApiEnabled,
     hasActiveLicense,
     setHasActiveLicense,
     getActiveLicenseStatus,

--- a/freely/src/pages/chats/components/ChatAudio.tsx
+++ b/freely/src/pages/chats/components/ChatAudio.tsx
@@ -17,8 +17,8 @@ export const ChatAudio = ({
   setIsRecording,
   disabled,
 }: ChatAudioProps) => {
-  const { selectedSttProvider, pluelyApiEnabled } = useApp();
-  const isProviderConfigured = pluelyApiEnabled || selectedSttProvider.provider;
+  const { selectedSttProvider, freelyApiEnabled } = useApp();
+  const isProviderConfigured = freelyApiEnabled || selectedSttProvider.provider;
 
   const handleMicClick = () => {
     if (!isProviderConfigured) {

--- a/freely/src/types/context.type.ts
+++ b/freely/src/types/context.type.ts
@@ -40,8 +40,8 @@ export type IContextType = {
   toggleAlwaysOnTop: (isEnabled: boolean) => Promise<void>;
   toggleAutostart: (isEnabled: boolean) => Promise<void>;
   loadData: () => void;
-  pluelyApiEnabled: boolean;
-  setPluelyApiEnabled: (enabled: boolean) => Promise<void>;
+  freelyApiEnabled: boolean;
+  setFreelyApiEnabled: (enabled: boolean) => Promise<void>;
   hasActiveLicense: boolean;
   setHasActiveLicense: Dispatch<SetStateAction<boolean>>;
   getActiveLicenseStatus: () => Promise<void>;


### PR DESCRIPTION
## Summary

Renames internal TypeScript identifiers from `pluely` to `freely`. Storage keys are intentionally preserved for backwards-compatibility with existing users.

**Changed identifiers:**
- `pluelyApiEnabled` → `freelyApiEnabled` (state + context value)
- `setPluelyApiEnabled` → `setFreelyApiEnabled` (setter + context value)
- `setPluelyApiEnabledState` → `setFreelyApiEnabledState` (internal useState setter)

**Files changed:**
- `freely/src/types/context.type.ts` — interface type updated
- `freely/src/contexts/app.context.tsx` — state, setter, and context object updated
- `freely/src/pages/chats/components/ChatAudio.tsx` — destructuring + usage updated

## Test plan
- [ ] Build succeeds with no new TypeScript errors
- [ ] Audio provider check still works correctly (mic button shows/hides as expected)