### PR TITLE
Migrate pluely.db → freely.db for existing users (#10)

### DIFF
--- a/freely/src-tauri/src/lib.rs
+++ b/freely/src-tauri/src/lib.rs
@@ -240,7 +240,7 @@ fn migrate_pluely_db(app: &AppHandle) {
 
     if old_path.exists() && !new_path.exists() {
         match std::fs::rename(&old_path, &new_path) {
-            Ok(()) => eprintln!(
+            Ok(()) => println!(
                 "[migrate_pluely_db] Renamed {:?} → {:?}",
                 old_path, new_path
             ),
@@ -248,6 +248,24 @@ fn migrate_pluely_db(app: &AppHandle) {
                 "[migrate_pluely_db] Failed to rename {:?} → {:?}: {}",
                 old_path, new_path, e
             ),
+        }
+
+        // Also rename SQLite WAL sidecar files if they exist.
+        for suffix in &["-wal", "-shm"] {
+            let old_sidecar = data_dir.join(format!("pluely.db{}", suffix));
+            let new_sidecar = data_dir.join(format!("freely.db{}", suffix));
+            if old_sidecar.exists() {
+                match std::fs::rename(&old_sidecar, &new_sidecar) {
+                    Ok(()) => println!(
+                        "[migrate_pluely_db] Renamed {:?} → {:?}",
+                        old_sidecar, new_sidecar
+                    ),
+                    Err(e) => eprintln!(
+                        "[migrate_pluely_db] Failed to rename {:?} → {:?}: {}",
+                        old_sidecar, new_sidecar, e
+                    ),
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Existing users who had \`pluely.db\` lose their conversation history when the app is renamed because \`tauri-plugin-sql\` now opens \`sqlite:freely.db\`. This adds a one-time migration step in the Rust \`setup()\` hook.

**How it works:**
- \`migrate_pluely_db()\` is called at the very start of \`setup()\`, before the SQL plugin opens the database (the plugin opens lazily on first JS access)
- Resolves \`app_local_data_dir()\` — the same directory \`tauri-plugin-sql\` uses for SQLite files
- If \`pluely.db\` exists **and** \`freely.db\` does not: renames \`pluely.db\` → \`freely.db\`
- If \`freely.db\` already exists (new install or already migrated): no-op, leaves both files alone
- Errors are logged to stderr but never fatal — a failed migration degrades gracefully to an empty DB

## Test plan
- [ ] Fresh install: \`freely.db\` is created normally, no migration attempted
- [ ] Upgrade from Pluely: \`pluely.db\` is renamed to \`freely.db\`; conversation history preserved
- [ ] Double-upgrade (already migrated): both files exist, no data loss
- [ ] \`cargo check\` passes with no new errors ✓