### PR TITLE
Release v0.1.0 — version sync

### DIFF
--- a/freely/package-lock.json
+++ b/freely/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freely",
-  "version": "0.1.9",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freely",
-      "version": "0.1.9",
+      "version": "0.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@bany/curl-to-json": "^1.2.8",
@@ -9846,6 +9846,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/freely/package.json
+++ b/freely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freely",
   "private": false,
-  "version": "0.1.9",
+  "version": "0.1.0",
   "description": "A lightning-fast, privacy-first AI assistant that works seamlessly during meetings, interviews, and conversations.",
   "author": {
     "name": "Srikanth Nani",

--- a/freely/src-tauri/Cargo.lock
+++ b/freely/src-tauri/Cargo.lock
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "freely"
-version = "0.1.9"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/freely/src-tauri/Cargo.toml
+++ b/freely/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freely"
-version = "0.1.9"
+version = "0.1.0"
 description = "A lightning-fast, privacy-first AI assistant that works seamlessly during meetings, interviews, and conversations."
 authors = ["Srikanth Nani <srikanthnani1202@gmail.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
Syncs all version files to 0.1.0 for the first Freely release. Closes #71 partially.

## Changes
- `freely/package.json` — 0.1.9 → 0.1.0
- `freely/src-tauri/Cargo.toml` — 0.1.9 → 0.1.0
- `freely/src-tauri/Cargo.lock` — 0.1.9 → 0.1.0
- `freely/package-lock.json` — updated via npm install
- `freely/src-tauri/tauri.conf.json` — already at 0.1.0